### PR TITLE
Fix for error on POST in zend-diactoros

### DIFF
--- a/src/Bridge/Psr7RequestBuilder.php
+++ b/src/Bridge/Psr7RequestBuilder.php
@@ -5,15 +5,19 @@ namespace WShafer\SwooleExpressive\Bridge;
 
 use Swoole\Http\Request as SwooleRequest;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Stream;
 
 class Psr7RequestBuilder
 {
     public function build(SwooleRequest $swooleRequest)
     {
-        $body = (string) $swooleRequest->rawcontent();
+        $rawContent = (string) $swooleRequest->rawcontent();
 
-        if (empty($body)) {
+        if (empty($rawContent)) {
             $body = 'php://input';
+        } else {
+            $body   = new Stream('php://memory', 'wb+');
+            $body->write($rawContent);
         }
 
         return new ServerRequest(

--- a/src/Bridge/Psr7RequestBuilder.php
+++ b/src/Bridge/Psr7RequestBuilder.php
@@ -13,9 +13,9 @@ class Psr7RequestBuilder
     {
         $rawContent = (string) $swooleRequest->rawcontent();
 
-        if (empty($rawContent)) {
-            $body = 'php://input';
-        } else {
+        $body = 'php://input';
+        
+        if (!empty($rawContent)) {
             $body   = new Stream('php://memory', 'wb+');
             $body->write($rawContent);
         }


### PR DESCRIPTION
An error occurs in` \Zend\Diactoros\Stream::setStream` when the raw content is a string that cannot be opened via fopen (i.e. an XML payload)